### PR TITLE
feat: skip fragment checking for unsupported MIME types

### DIFF
--- a/fixtures/fragments/file1.md
+++ b/fixtures/fragments/file1.md
@@ -83,17 +83,10 @@ Even with fragment checking enabled, the following links must hence succeed:
 [Link to remote binary file without fragment](https://raw.githubusercontent.com/lycheeverse/lychee/master/fixtures/fragments/zero.bin)
 [Link to remote binary file with empty fragment](https://raw.githubusercontent.com/lycheeverse/lychee/master/fixtures/fragments/zero.bin#)
 
-## Local file with fragment
+## With fragment
 
-For local files URIs with fragment, the fragment checker is invoked and fails to read the content,
-but the file checker emits a warning only. The following link hence must succeed as well:
+Fragment checking is skipped if the Content-Type header is not "text/html", "text/markdown", or "text/plain" with ".md" URL path ending.
+Even that the URL contains a fragment, the following checks must hence succeed:
 
 [Link to local binary file with fragment](zero.bin#fragment)
-
-## Remote URL with fragment
-
-Right now, there is not MIME/content type based exclusion for fragment checks in the website checker.
-Also, other than the file checker, the website checker throws an error if reading the response body fails.
-The following link hence must fail:
-
 [Link to remote binary file with fragment](https://raw.githubusercontent.com/lycheeverse/lychee/master/fixtures/fragments/zero.bin#fragment)

--- a/lychee-bin/tests/cli.rs
+++ b/lychee-bin/tests/cli.rs
@@ -1889,9 +1889,9 @@ mod cli {
                 "https://raw.githubusercontent.com/lycheeverse/lychee/master/fixtures/fragments/zero.bin#fragment",
             ))
             .stdout(contains("34 Total"))
-            .stdout(contains("28 OK"))
+            .stdout(contains("29 OK"))
             // Failures because of missing fragments or failed binary body scan
-            .stdout(contains("6 Errors"));
+            .stdout(contains("5 Errors"));
     }
 
     #[test]


### PR DESCRIPTION
The remote URL/website checker currently passes all URLs with fragments to the fragment checker as HTML document, even if it is a different or unsupported MIME type. This can cause false fragment checking for Markdown documents, failures for other MIME types, especially binaries, and unnecessary traffic for large downloads, which are always finished completely, if the fragment checker is invoked.

This commit checks the Content-Type header of the response:
- Only if it is `text/html`, it is passed to the fragment checker as HTML type.
- Only if it is `text/markdown`, of `text/plain` and URL path ends on `.md`, it is passed to the fragment checker as Markdown type.
- In all other cases, the fragment checker is skipped and the HTTP status is returned.

To invoke the fragment checker with a variable document type, a new `FileType` argument is added to the `check_html_fragment()` function.

The fragment checker test and fixture are adjusted to match the expected result: checking a binary file via remote URL with fragment is now expected to succeed, since its Content-Type header does not invoke the fragment checker anymore.